### PR TITLE
Remove severity failure in places that depend on runtime values

### DIFF
--- a/modules/axi/src/axi_lite_pkg.vhd
+++ b/modules/axi/src/axi_lite_pkg.vhd
@@ -283,7 +283,7 @@ package body axi_lite_pkg is
     hi := lo + axi_w_strb_width(data_width) - 1;
     result(hi downto lo) := data.strb(axi_w_strb_width(data_width) - 1 downto 0);
 
-    assert hi = result'high severity failure;
+    assert hi = result'high;
 
     return result;
   end function;
@@ -302,7 +302,7 @@ package body axi_lite_pkg is
     hi := lo + axi_w_strb_width(data_width) - 1;
     result.strb(axi_w_strb_width(data_width) - 1 downto 0) := data(hi downto lo);
 
-    assert hi = data'high severity failure;
+    assert hi = data'high;
 
     return result;
   end function;
@@ -333,7 +333,7 @@ package body axi_lite_pkg is
     hi := lo + axi_resp_sz - 1;
     result(hi downto lo) := data.resp;
 
-    assert hi = result'high severity failure;
+    assert hi = result'high;
 
     return result;
   end function;
@@ -352,7 +352,7 @@ package body axi_lite_pkg is
     hi := lo + axi_resp_sz - 1;
     result.resp := data(hi downto lo);
 
-    assert hi = data'high severity failure;
+    assert hi = data'high;
 
     return result;
   end function;

--- a/modules/axi/src/axi_pkg.vhd
+++ b/modules/axi/src/axi_pkg.vhd
@@ -471,7 +471,7 @@ package body axi_pkg is
     hi := lo + data.burst'length - 1;
     result(hi downto lo) := data.burst;
 
-    assert hi = result'high severity failure;
+    assert hi = result'high;
 
     return result;
   end function;
@@ -603,7 +603,7 @@ package body axi_pkg is
     hi := lo;
     result(hi) := data.last;
 
-    assert hi = result'high severity failure;
+    assert hi = result'high;
 
     return result;
   end function;
@@ -633,7 +633,7 @@ package body axi_pkg is
     hi := lo;
     result.last := data(hi + offset);
 
-    assert hi + offset = data'high severity failure;
+    assert hi + offset = data'high;
 
     return result;
   end function;
@@ -662,7 +662,7 @@ package body axi_pkg is
     hi := lo + axi_resp_sz - 1;
     result(hi downto lo) := data.resp;
 
-    assert hi = result'high severity failure;
+    assert hi = result'high;
 
     return result;
   end function;
@@ -684,7 +684,7 @@ package body axi_pkg is
     hi := lo + axi_resp_sz - 1;
     result.resp := data(hi + offset downto lo + offset);
 
-    assert hi + offset = data'high severity failure;
+    assert hi + offset = data'high;
 
     return result;
   end function;
@@ -730,7 +730,7 @@ package body axi_pkg is
     hi := lo;
     result(hi) := data.last;
 
-    assert hi = result'high severity failure;
+    assert hi = result'high;
 
     return result;
   end function;
@@ -762,7 +762,7 @@ package body axi_pkg is
     hi := lo;
     result.last := data(hi + offset);
 
-    assert hi + offset = data'high severity failure;
+    assert hi + offset = data'high;
 
     return result;
   end function;

--- a/modules/axi/src/axi_stream_pkg.vhd
+++ b/modules/axi/src/axi_stream_pkg.vhd
@@ -126,7 +126,7 @@ package body axi_stream_pkg is
     hi := lo + user_width - 1;
     result(hi downto lo) := data.user(user_width - 1 downto 0);
 
-    assert hi = result'high report "Something wrong with widths" severity failure;
+    assert hi = result'high;
 
     return result;
   end function;
@@ -153,7 +153,7 @@ package body axi_stream_pkg is
     hi := lo + user_width - 1;
     result.user(user_width - 1 downto 0) := data(hi + offset downto lo + offset);
 
-    assert hi + offset = data'high report "Something wrong with widths" severity failure;
+    assert hi + offset = data'high;
 
     result.valid := valid;
 

--- a/modules/common/src/keep_remover.vhd
+++ b/modules/common/src/keep_remover.vhd
@@ -105,7 +105,8 @@ architecture a of keep_remover is
 begin
 
   assert data_width mod strobe_unit_width = 0
-    report "Data width must be a multiple of strobe unit width." severity failure;
+    report "Data width must be a multiple of strobe unit width."
+    severity failure;
 
 
   ------------------------------------------------------------------------------

--- a/modules/common/src/types_pkg.vhd
+++ b/modules/common/src/types_pkg.vhd
@@ -135,7 +135,7 @@ package body types_pkg is
     elsif value = '0' then
       return false;
     end if;
-    assert false report "Can not convert value: " & std_logic'image(value) severity failure;
+    assert false report "Can not convert value: " & std_logic'image(value);
     return false;
   end function;
 
@@ -148,7 +148,7 @@ package body types_pkg is
       return false;
     end if;
 
-    assert false report "Can not convert value: " & natural'image(value) severity failure;
+    assert false report "Can not convert value: " & natural'image(value);
     return false;
   end function;
 
@@ -185,8 +185,8 @@ package body types_pkg is
     -- Swap endianness of the input word.
     -- I.e., while maintaining the range and vector direction, swap the location of the data bytes.
 
-    assert data'left > data'right report "Only use with descending range" severity failure;
-    assert data'length mod 8 = 0 report "Must be a whole number of bytes" severity failure;
+    assert data'left > data'right report "Only use with descending range";
+    assert data'length mod 8 = 0 report "Must be a whole number of bytes";
 
     for input_byte_idx in 0 to num_bytes - 1 loop
       result_byte_idx := num_bytes - 1 - input_byte_idx;

--- a/modules/common/src/width_conversion.vhd
+++ b/modules/common/src/width_conversion.vhd
@@ -399,7 +399,7 @@ begin
           packed_atom(hi) := input_atoms(input_atom_idx).last;
         end if;
 
-        assert hi = packed_atom'high report "Something wrong with widths";
+        assert hi = packed_atom'high;
 
         input_packed(
           (input_atom_idx + 1) * packed_atom'length - 1 downto input_atom_idx * packed_atom'length
@@ -494,7 +494,7 @@ begin
           output_atoms(output_atom_idx).last <= packed_atom(hi);
         end if;
 
-        assert hi = packed_atom'high report "Something wrong with widths";
+        assert hi = packed_atom'high;
       end loop;
     end process;
 

--- a/modules/fifo/src/asynchronous_fifo.vhd
+++ b/modules/fifo/src/asynchronous_fifo.vhd
@@ -152,8 +152,7 @@ begin
     wait until rising_edge(clk_write);
 
     assert enable_drop_packet or drop_packet = '0'
-      report "Must enable 'drop_packet' using generic"
-      severity failure;
+      report "Must enable 'drop_packet' using generic";
   end process;
 
 

--- a/modules/fifo/src/fifo.vhd
+++ b/modules/fifo/src/fifo.vhd
@@ -181,12 +181,10 @@ begin
     wait until rising_edge(clk);
 
     assert enable_peek_mode or read_peek_mode = '0'
-      report "Must enable 'peek_mode' using generic"
-      severity failure;
+      report "Must enable 'peek_mode' using generic";
 
     assert enable_drop_packet or drop_packet = '0'
-      report "Must enable 'drop_packet' using generic"
-      severity failure;
+      report "Must enable 'drop_packet' using generic";
   end process;
 
 

--- a/modules/math/src/math_pkg.vhd
+++ b/modules/math/src/math_pkg.vhd
@@ -161,8 +161,8 @@ package body math_pkg is
 
   function clamp(value, min, max : signed) return signed is
   begin
-    assert min'length <= value'length report "Min value can not be assigned" severity failure;
-    assert max'length <= value'length report "Max value can not be assigned" severity failure;
+    assert min'length <= value'length report "Min value can not be assigned";
+    assert max'length <= value'length report "Max value can not be assigned";
 
     if value < min then
       return resize(min, value'length);
@@ -191,9 +191,8 @@ package body math_pkg is
   function log2(value : positive) return natural is
   begin
     -- 2-base logarithm where argument must be a power of two
-    assert is_power_of_two(value)
-      report "Must be power of two: " & to_string(value)
-      severity failure;
+    assert is_power_of_two(value) report "Must be power of two: " & to_string(value);
+
     return floor_log2(value);
   end function;
 
@@ -255,6 +254,7 @@ package body math_pkg is
     assert value <= 2**result - 1
       report "Calculated value not correct: " & to_string(value) & " " & to_string(result)
       severity failure;
+
     return result;
   end function;
 

--- a/modules/resync/src/resync_level.vhd
+++ b/modules/resync/src/resync_level.vhd
@@ -95,8 +95,7 @@ begin
   ------------------------------------------------------------------------------
   assign_input : if enable_input_register generate
 
-    -- This check will trigger in simulation, but will probably not work in synthesis
-    assert clk_in /= 'U' report "Must assign clock when using input register" severity failure;
+    assert clk_in /= 'U' report "Must assign clock when using input register";
 
 
     ------------------------------------------------------------------------------


### PR DESCRIPTION
Has been shown to produce logic by Vivado synthesis. Keep the severity failure in places that are not expected to be dependent on runtime values.