### PR TITLE
asynchronous_fifo.tcl: Make constraints compatible with ultrascale

### DIFF
--- a/modules/fifo/scoped_constraints/asynchronous_fifo.tcl
+++ b/modules/fifo/scoped_constraints/asynchronous_fifo.tcl
@@ -17,7 +17,7 @@ set clk_write [get_clocks -quiet -of_objects [get_ports "clk_write"]]
 set read_data [
   get_cells \
     -quiet \
-    -filter {PRIMITIVE_GROUP==FLOP_LATCH} \
+    -filter {PRIMITIVE_GROUP==FLOP_LATCH || PRIMITIVE_GROUP==REGISTER} \
     "memory.memory_read_data_reg*"
 ]
 


### PR DESCRIPTION
The primitive group for registers do not have the same name in 7-series and ultrascale.