### PR TITLE
Revert "Fix sphinx HTML math rendering"

### DIFF
--- a/modules/lfsr/doc/lfsr.rst
+++ b/modules/lfsr/doc/lfsr.rst
@@ -7,7 +7,7 @@ The maximum-length LFSR has the attractive property that it cycles through
 
 .. math::
 
-    2^\text{lfsr\_length} - 1
+    2^\text{lfsr_length} - 1
 
 unique states before repeating.
 While the order of the states is completely deterministic, the output bit of the LFSR

--- a/modules/sine_generator/doc/sine_generator.rst
+++ b/modules/sine_generator/doc/sine_generator.rst
@@ -56,9 +56,9 @@ It is given by
 
 .. math::
 
-  \text{frequency\_resolution\_hz} \equiv \frac{\text{clk\_frequency\_hz}}{2^\text{phase\_width}}
-    = \frac{\text{clk\_frequency\_hz}}{
-      2^{\text{memory\_address\_width} + 2 + \text{phase\_fractional\_width}}
+  \text{frequency_resolution_hz} \equiv \frac{\text{clk_frequency_hz}}{2^\text{phase_width}}
+    = \frac{\text{clk_frequency_hz}}{
+      2^{\text{memory_address_width} + 2 + \text{phase_fractional_width}}
     }.
 
 Where ``clk_frequency_hz`` is the frequency of the system clock that is clocking this module,
@@ -80,7 +80,7 @@ Note that the module will always use a memory that is
 
 .. math::
 
-  2^\text{memory\_address\_width} \times \text{memory\_data\_width}
+  2^\text{memory_address_width} \times \text{memory_data_width}
 
 large, and you must hence choose a maximum memory size that your design can afford.
 The  ``memory_data_width`` is typically  18 and ``memory_address_width`` between 9 and 12, since
@@ -99,7 +99,7 @@ The SFDR of the output signal is at least
 
 .. math::
 
-  \text{SFDR} = 6 \times (\text{memory\_data\_width} + 1) \text{ dB}.
+  \text{SFDR} = 6 \times (\text{memory_data_width} + 1) \text{ dB}.
 
 Use this equation to determine the ``memory_data_width`` generic value you need, given your
 SFDR requirement.
@@ -115,10 +115,10 @@ If we reorder the :ref:`sine_frequency_resolution` equation above, we get
 
 .. math::
 
-  \text{phase\_fractional\_width} = \left\lceil
-    \log_2 \left( \frac{\text{clk\_frequency\_hz}}{\text{frequency\_resolution\_hz}} \right)
+  \text{phase_fractional_width} = \left\lceil
+    \log_2 \left( \frac{\text{clk_frequency_hz}}{\text{frequency_resolution_hz}} \right)
   \right\rceil
-  - \text{memory\_address\_width} - 2.
+  - \text{memory_address_width} - 2.
 
 Use this to calculate the ``phase_fractional_width`` generic value needed.
 
@@ -149,7 +149,7 @@ If neither dithering nor Taylor expansion is enabled, the SFDR of the output sig
 
 .. math::
 
-  \text{SFDR} = 6 \times (\text{memory\_address\_width} + 1) \text{ dB}.
+  \text{SFDR} = 6 \times (\text{memory_address_width} + 1) \text{ dB}.
 
 Use this equation to determine the ``memory_address_width`` generic value you need, given your
 SFDR requirement.
@@ -165,7 +165,7 @@ to at least
 
 .. math::
 
-  \text{SFDR} = 6 \times (\text{memory\_address\_width} + 4) \text{ dB}.
+  \text{SFDR} = 6 \times (\text{memory_address_width} + 4) \text{ dB}.
 
 Use this equation to determine the ``memory_address_width`` generic value you need, given your
 SFDR requirement.
@@ -181,7 +181,7 @@ to at least
 
 .. math::
 
-  \text{SFDR} = 12 \times (\text{memory\_address\_width} + 1) \text{ dB}.
+  \text{SFDR} = 12 \times (\text{memory_address_width} + 1) \text{ dB}.
 
 Use this equation to determine the ``memory_address_width`` generic value you need, given your
 SFDR requirement.

--- a/modules/sine_generator/src/sine_calculator.vhd
+++ b/modules/sine_generator/src/sine_calculator.vhd
@@ -73,7 +73,7 @@
 --
 -- .. math::
 --
---   B \equiv \frac{\pi / 2}{2^\text{memory\_address\_width}}.
+--   B \equiv \frac{\pi / 2}{2^\text{memory_address_width}}.
 --
 -- The calculation is partitioned like this, using DSP48 blocks:
 --

--- a/modules/sine_generator/src/sine_generator.vhd
+++ b/modules/sine_generator/src/sine_generator.vhd
@@ -29,7 +29,7 @@
 --
 -- .. math::
 --
---   \text{phase\_width} = \text{memory\_address\_width} + 2 + \text{phase\_fractional\_width}
+--   \text{phase_width} = \text{memory_address_width} + 2 + \text{phase_fractional_width}
 --
 -- In VHDL you are recommended to utilize the ``get_phase_width`` function in
 -- :ref:`sine_generator.sine_generator_pkg`.
@@ -38,8 +38,8 @@
 --
 -- .. math::
 --
---   \text{phase\_increment} = \text{int} \left(
---     \frac{\text{sine\_frequency\_hz}}{\text{clk\_frequency\_hz}} \times 2^\text{phase\_width}
+--   \text{phase_increment} = \text{int} \left(
+--     \frac{\text{sine_frequency_hz}}{\text{clk_frequency_hz}} \times 2^\text{phase_width}
 --    \right).
 --
 -- Where ``sine_frequency_hz`` is the target sinus output frequency, and ``clk_frequency_hz`` is

--- a/modules/sine_generator/src/sine_lookup.vhd
+++ b/modules/sine_generator/src/sine_lookup.vhd
@@ -79,38 +79,38 @@
 -- Fixed-point representation
 -- __________________________
 --
--- When we want to distribute :math:`2^\text{memory\_address\_width}` number of points over the
--- phase range :math:`[0, \pi / 2[`, we use
+-- When we want to distribute :math:`2^\text{memory_address_width}` number of points over the phase
+-- range :math:`[0, \pi / 2[`, we use
 --
 -- .. math::
 --
---   \text{phase\_increment} \equiv \frac{\pi / 2}{2^\text{memory\_address\_width}}.
+--   \text{phase_increment} \equiv \frac{\pi / 2}{2^\text{memory_address_width}}.
 --
 -- To achieve the symmetry we aim for in the discussion above, we offset the phase by half an LSB:
 --
 -- .. math::
 --
---   \phi \equiv \frac{\text{phase\_increment}}{2}.
+--   \phi \equiv \frac{\text{phase_increment}}{2}.
 --
 -- This gives a total phase of
 --
 -- .. math::
 --
---   \theta(i) \equiv i \times \text{phase\_increment} + \phi.
+--   \theta(i) \equiv i \times \text{phase_increment} + \phi.
 --
 -- We also have an amplitude-quantization given by the ``memory_data_width`` generic.
 -- This gives a maximum amplitude of
 --
 -- .. math::
 --
---   A \equiv 2^\text{memory\_data\_width} - 1.
+--   A \equiv 2^\text{memory_data_width} - 1.
 --
 -- With this established, we can calculate the memory values as
 --
 -- .. math::
 --
 --   \text{mem} (i) = \text{int} \left(  A \times \sin(\theta(i)) \right),
---     \forall i \in [0, 2^\text{memory\_address\_width} - 1].
+--     \forall i \in [0, 2^\text{memory_address_width} - 1].
 --
 -- As can be seen in the trigonometric identities above, the resulting output sine value from this
 -- entity is negated in some some quadrants.


### PR DESCRIPTION
No idea what's going on with the dependencies.
Two weeks ago underscores didn't render, but escaped underscores rendered properly. Now the backslash and the underscore render.

This reverts commit 2161f6cde157150ef8d27fab911b3ca9ecaffcec.